### PR TITLE
Barcodes & GPS no longer break dynamically rendered edit modals in datagrids

### DIFF
--- a/src/components/BarcodeScanner/BarcodeScanner.js
+++ b/src/components/BarcodeScanner/BarcodeScanner.js
@@ -78,36 +78,45 @@ export default class BarcodeScanner extends FieldComponent {
   }
 
   attach(element) {
+    const attached = super.attach(element);
+
     this.loadRefs(element, {
       barcode: "single",
       scanButton: "single",
       fileInput: "single",
     });
 
-    if (this.dataValue) {
-      this.refs.barcode.value = this.dataValue;
-    }
+    if (!this.refs.barcode || !this.refs.scanButton || !this.refs.fileInput) {
+        console.warn("BarcodeScanner refs not ready. Skipping event bindings.");
+        return;
+      }
 
-    if (!this.component.disabled) {
-      this.refs.barcode.addEventListener("change", () => {
-        this.updateValue(this.refs.barcode.value);
-      });
+      if (this.dataValue) {
+        this.refs.barcode.value = this.dataValue;
+      }
 
-      this.refs.scanButton.addEventListener("click", () => {
-        setTimeout(() => {
-          this.refs.fileInput.dispatchEvent(new MouseEvent("click"));
-        }, 0);
-      });
+      if (!this.component.disabled) {
+        this.refs.barcode.addEventListener("change", () => {
+          this.updateValue(this.refs.barcode.value);
+        });
 
-      this.refs.fileInput.addEventListener("change", (event) => {
-        if (event.target.files.length > 0) {
-          const file = event.target.files[0];
-          this.decodeBarcode(file);
-        }
-      });
-    }
-    return super.attach(element);
+        this.refs.scanButton.addEventListener("click", () => {
+          setTimeout(() => {
+            this.refs.fileInput.dispatchEvent(new MouseEvent("click"));
+          }, 0);
+        });
+
+        this.refs.fileInput.addEventListener("change", (event) => {
+          if (event.target.files.length > 0) {
+            const file = event.target.files[0];
+            this.decodeBarcode(file);
+          }
+        });
+      }
+
+    return attached;
   }
+
 
   async decodeBarcode(file) {
     const reader = new FileReader();
@@ -170,16 +179,17 @@ export default class BarcodeScanner extends FieldComponent {
 
   detach() {
     if (this.refs.barcode) {
-      this.refs.barcode.removeEventListener("change", this.updateValue);
+      this.refs.barcode.removeEventListener("change", () => this.updateValue(this.refs.barcode.value));
     }
     if (this.refs.scanButton) {
-      this.refs.scanButton.removeEventListener("click", this.handleScanClick);
+      this.refs.scanButton.removeEventListener("click", this.scanButtonClickHandler);
     }
     if (this.refs.fileInput) {
-      this.refs.fileInput.removeEventListener("change", this.handleFileChange);
+      this.refs.fileInput.removeEventListener("change", this.fileInputChangeHandler);
     }
     return super.detach();
   }
+
 
   destroy() {
     return super.destroy();

--- a/src/components/Gps/Gps.js
+++ b/src/components/Gps/Gps.js
@@ -91,24 +91,30 @@ export default class Gps extends FieldComponent {
     });
 
     if (!this.component.disabled) {
-      this.refs.latitude.addEventListener("change", () => {
-        const latitude = this.refs.latitude.value;
-        const longitude = this.refs.longitude.value;
-        this.updateValue(`${latitude},${longitude}`);
-      });
+      if (this.refs.latitude && this.refs.longitude) {
+        this.refs.latitude.addEventListener("change", () => {
+          const latitude = this.refs.latitude.value;
+          const longitude = this.refs.longitude.value;
+          this.updateValue(`${latitude},${longitude}`);
+        });
 
-      this.refs.longitude.addEventListener("change", () => {
-        const latitude = this.refs.latitude.value;
-        const longitude = this.refs.longitude.value;
-        this.updateValue(`${latitude},${longitude}`);
-      });
+        this.refs.longitude.addEventListener("change", () => {
+          const latitude = this.refs.latitude.value;
+          const longitude = this.refs.longitude.value;
+          this.updateValue(`${latitude},${longitude}`);
+        });
+      }
 
-      this.refs.gpsButton.addEventListener("click", () => {
-        this.getLocation();
-      });
+      if (this.refs.gpsButton) {
+        this.refs.gpsButton.addEventListener("click", () => {
+          this.getLocation();
+        });
+      }
     }
+
     return super.attach(element);
   }
+
 
   getLocation() {
     if (!navigator.geolocation) {


### PR DESCRIPTION
Barcodes no longer break dynamically rendered edit modals in datagrids

Attaches GPS event listeners after component loads

Ensures that GPS event listeners are attached only after the component's references are loaded, preventing potential errors. This is achieved by wrapping the event listener attachment logic within a `setTimeout` function with a delay of 0 milliseconds and adding conditions to check if the refs are present.